### PR TITLE
rethinkdns

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2343,6 +2343,15 @@ Maintained by publicarray - https://dns.seby.io
 sdns://AgcAAAAAAAAADTEzOS45OS4yMjIuNzKgzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9NgOYgRE69Z7uD-IB7OSHpOKyReLiCvVCq2xEjHwRM9fCN984NZG9oLTIuc2VieS5pbwovZG5zLXF1ZXJ5
 
 
+## rethinkdns
+
+Rethink DNS is both a stub and a recursive resolver running on Cloudfare's network. sky.rethinkdns.com forwards user requests to another recursive resolver like Cloudflare's 1.1.1.1, but does so in a way that doesn't leak the identity of the client (user). 
+DNSSEC, no filter, no logs.
+https://www.rethinkdns.com/
+
+sdns://AgcAAAAAAAAAACARsQLmsfY-UomE1gJfMrE4JB_Ii711GVdNcMmDLVPh6BJza3kucmV0aGlua2Rucy5jb20KL2Rucy1xdWVyeQ
+
+
 ## qihoo360-doh
 
 DoH server runned by Qihoo 360, has logs, supports DNSSEC. GFW filtering rules are applied.


### PR DESCRIPTION
Regarding the correct certificate hash, the -show-certs command-line flag shows this output for rethinkdns: 
[NOTICE] Advertised cert: [CN=rethinkdns.com] [6bd089f78d2efbc7d0a6870a2abe7d7be9245e035831ffa41e2429396d9e5488] 
[NOTICE] Advertised cert: [CN=E1,O=Let's Encrypt,C=US] [cc1060d39c8329b62b6fbc7d0d6df9309869b981e7e6392d5cd8fa408f4d80e6] 
[NOTICE] Advertised cert: [CN=ISRG Root X2,O=Internet Security Research Group,C=US] [5aef843ffcf2ec7055f504a162f229f8391c370ff3a6163d2db3f3d604d622be] 
[NOTICE] Advertised cert: [CN=ISRG Root X1,O=Internet Security Research Group,C=US] [11b102e6b1f63e528984d6025f32b138241fc88bbd7519574d70c9832d53e1e8]

I have used the last hash to create the dns stamp.